### PR TITLE
build: add secure Akka repo to exercise poms

### DIFF
--- a/Exercises/0_begin/pom.xml
+++ b/Exercises/0_begin/pom.xml
@@ -20,4 +20,11 @@
   <dependencies>
     <!-- Your dependencies go here -->
   </dependencies>
+  <repositories>
+    <repository>
+      <id>akka-secure</id>
+      <name>Akka Secure</name>
+      <url>https://repo.akka.io/rzfWF62AxO3gu_9uXal1adFoxkZqnUXQJoGKTXjfCsL2bjvg/secure</url>
+    </repository>
+  </repositories>
 </project>

--- a/Exercises/0_solution/pom.xml
+++ b/Exercises/0_solution/pom.xml
@@ -20,4 +20,11 @@
   <dependencies>
     <!-- Your dependencies go here -->
   </dependencies>
+  <repositories>
+    <repository>
+      <id>akka-secure</id>
+      <name>Akka Secure</name>
+      <url>https://repo.akka.io/rzfWF62AxO3gu_9uXal1adFoxkZqnUXQJoGKTXjfCsL2bjvg/secure</url>
+    </repository>
+  </repositories>
 </project>

--- a/Exercises/10_begin/pom.xml
+++ b/Exercises/10_begin/pom.xml
@@ -20,4 +20,11 @@
   <dependencies>
     <!-- Your dependencies go here -->
   </dependencies>
+  <repositories>
+    <repository>
+      <id>akka-secure</id>
+      <name>Akka Secure</name>
+      <url>https://repo.akka.io/rzfWF62AxO3gu_9uXal1adFoxkZqnUXQJoGKTXjfCsL2bjvg/secure</url>
+    </repository>
+  </repositories>
 </project>

--- a/Exercises/10_solution/pom.xml
+++ b/Exercises/10_solution/pom.xml
@@ -20,4 +20,11 @@
   <dependencies>
     <!-- Your dependencies go here -->
   </dependencies>
+  <repositories>
+    <repository>
+      <id>akka-secure</id>
+      <name>Akka Secure</name>
+      <url>https://repo.akka.io/rzfWF62AxO3gu_9uXal1adFoxkZqnUXQJoGKTXjfCsL2bjvg/secure</url>
+    </repository>
+  </repositories>
 </project>

--- a/Exercises/11_begin/pom.xml
+++ b/Exercises/11_begin/pom.xml
@@ -20,4 +20,11 @@
   <dependencies>
     <!-- Your dependencies go here -->
   </dependencies>
+  <repositories>
+    <repository>
+      <id>akka-secure</id>
+      <name>Akka Secure</name>
+      <url>https://repo.akka.io/rzfWF62AxO3gu_9uXal1adFoxkZqnUXQJoGKTXjfCsL2bjvg/secure</url>
+    </repository>
+  </repositories>
 </project>

--- a/Exercises/11_solution/pom.xml
+++ b/Exercises/11_solution/pom.xml
@@ -20,4 +20,11 @@
   <dependencies>
     <!-- Your dependencies go here -->
   </dependencies>
+  <repositories>
+    <repository>
+      <id>akka-secure</id>
+      <name>Akka Secure</name>
+      <url>https://repo.akka.io/rzfWF62AxO3gu_9uXal1adFoxkZqnUXQJoGKTXjfCsL2bjvg/secure</url>
+    </repository>
+  </repositories>
 </project>

--- a/Exercises/12_begin/pom.xml
+++ b/Exercises/12_begin/pom.xml
@@ -20,4 +20,11 @@
   <dependencies>
     <!-- Your dependencies go here -->
   </dependencies>
+  <repositories>
+    <repository>
+      <id>akka-secure</id>
+      <name>Akka Secure</name>
+      <url>https://repo.akka.io/rzfWF62AxO3gu_9uXal1adFoxkZqnUXQJoGKTXjfCsL2bjvg/secure</url>
+    </repository>
+  </repositories>
 </project>

--- a/Exercises/12_solution/pom.xml
+++ b/Exercises/12_solution/pom.xml
@@ -20,4 +20,11 @@
   <dependencies>
     <!-- Your dependencies go here -->
   </dependencies>
+  <repositories>
+    <repository>
+      <id>akka-secure</id>
+      <name>Akka Secure</name>
+      <url>https://repo.akka.io/rzfWF62AxO3gu_9uXal1adFoxkZqnUXQJoGKTXjfCsL2bjvg/secure</url>
+    </repository>
+  </repositories>
 </project>

--- a/Exercises/1_begin/pom.xml
+++ b/Exercises/1_begin/pom.xml
@@ -20,4 +20,11 @@
   <dependencies>
     <!-- Your dependencies go here -->
   </dependencies>
+  <repositories>
+    <repository>
+      <id>akka-secure</id>
+      <name>Akka Secure</name>
+      <url>https://repo.akka.io/rzfWF62AxO3gu_9uXal1adFoxkZqnUXQJoGKTXjfCsL2bjvg/secure</url>
+    </repository>
+  </repositories>
 </project>

--- a/Exercises/1_solution/pom.xml
+++ b/Exercises/1_solution/pom.xml
@@ -20,4 +20,11 @@
   <dependencies>
     <!-- Your dependencies go here -->
   </dependencies>
+  <repositories>
+    <repository>
+      <id>akka-secure</id>
+      <name>Akka Secure</name>
+      <url>https://repo.akka.io/rzfWF62AxO3gu_9uXal1adFoxkZqnUXQJoGKTXjfCsL2bjvg/secure</url>
+    </repository>
+  </repositories>
 </project>

--- a/Exercises/2_begin/pom.xml
+++ b/Exercises/2_begin/pom.xml
@@ -20,4 +20,11 @@
   <dependencies>
     <!-- Your dependencies go here -->
   </dependencies>
+  <repositories>
+    <repository>
+      <id>akka-secure</id>
+      <name>Akka Secure</name>
+      <url>https://repo.akka.io/rzfWF62AxO3gu_9uXal1adFoxkZqnUXQJoGKTXjfCsL2bjvg/secure</url>
+    </repository>
+  </repositories>
 </project>

--- a/Exercises/2_solution/pom.xml
+++ b/Exercises/2_solution/pom.xml
@@ -20,4 +20,11 @@
   <dependencies>
     <!-- Your dependencies go here -->
   </dependencies>
+  <repositories>
+    <repository>
+      <id>akka-secure</id>
+      <name>Akka Secure</name>
+      <url>https://repo.akka.io/rzfWF62AxO3gu_9uXal1adFoxkZqnUXQJoGKTXjfCsL2bjvg/secure</url>
+    </repository>
+  </repositories>
 </project>

--- a/Exercises/3_begin/pom.xml
+++ b/Exercises/3_begin/pom.xml
@@ -20,4 +20,11 @@
   <dependencies>
     <!-- Your dependencies go here -->
   </dependencies>
+  <repositories>
+    <repository>
+      <id>akka-secure</id>
+      <name>Akka Secure</name>
+      <url>https://repo.akka.io/rzfWF62AxO3gu_9uXal1adFoxkZqnUXQJoGKTXjfCsL2bjvg/secure</url>
+    </repository>
+  </repositories>
 </project>

--- a/Exercises/3_solution/pom.xml
+++ b/Exercises/3_solution/pom.xml
@@ -20,4 +20,11 @@
   <dependencies>
     <!-- Your dependencies go here -->
   </dependencies>
+  <repositories>
+    <repository>
+      <id>akka-secure</id>
+      <name>Akka Secure</name>
+      <url>https://repo.akka.io/rzfWF62AxO3gu_9uXal1adFoxkZqnUXQJoGKTXjfCsL2bjvg/secure</url>
+    </repository>
+  </repositories>
 </project>

--- a/Exercises/4_begin/pom.xml
+++ b/Exercises/4_begin/pom.xml
@@ -20,4 +20,11 @@
   <dependencies>
     <!-- Your dependencies go here -->
   </dependencies>
+  <repositories>
+    <repository>
+      <id>akka-secure</id>
+      <name>Akka Secure</name>
+      <url>https://repo.akka.io/rzfWF62AxO3gu_9uXal1adFoxkZqnUXQJoGKTXjfCsL2bjvg/secure</url>
+    </repository>
+  </repositories>
 </project>

--- a/Exercises/4_solution/pom.xml
+++ b/Exercises/4_solution/pom.xml
@@ -20,4 +20,11 @@
   <dependencies>
     <!-- Your dependencies go here -->
   </dependencies>
+  <repositories>
+    <repository>
+      <id>akka-secure</id>
+      <name>Akka Secure</name>
+      <url>https://repo.akka.io/rzfWF62AxO3gu_9uXal1adFoxkZqnUXQJoGKTXjfCsL2bjvg/secure</url>
+    </repository>
+  </repositories>
 </project>

--- a/Exercises/5_begin/pom.xml
+++ b/Exercises/5_begin/pom.xml
@@ -20,4 +20,11 @@
   <dependencies>
     <!-- Your dependencies go here -->
   </dependencies>
+  <repositories>
+    <repository>
+      <id>akka-secure</id>
+      <name>Akka Secure</name>
+      <url>https://repo.akka.io/rzfWF62AxO3gu_9uXal1adFoxkZqnUXQJoGKTXjfCsL2bjvg/secure</url>
+    </repository>
+  </repositories>
 </project>

--- a/Exercises/5_solution/pom.xml
+++ b/Exercises/5_solution/pom.xml
@@ -20,4 +20,11 @@
   <dependencies>
     <!-- Your dependencies go here -->
   </dependencies>
+  <repositories>
+    <repository>
+      <id>akka-secure</id>
+      <name>Akka Secure</name>
+      <url>https://repo.akka.io/rzfWF62AxO3gu_9uXal1adFoxkZqnUXQJoGKTXjfCsL2bjvg/secure</url>
+    </repository>
+  </repositories>
 </project>

--- a/Exercises/6_begin/pom.xml
+++ b/Exercises/6_begin/pom.xml
@@ -20,4 +20,11 @@
   <dependencies>
     <!-- Your dependencies go here -->
   </dependencies>
+  <repositories>
+    <repository>
+      <id>akka-secure</id>
+      <name>Akka Secure</name>
+      <url>https://repo.akka.io/rzfWF62AxO3gu_9uXal1adFoxkZqnUXQJoGKTXjfCsL2bjvg/secure</url>
+    </repository>
+  </repositories>
 </project>

--- a/Exercises/6_solution/pom.xml
+++ b/Exercises/6_solution/pom.xml
@@ -20,4 +20,11 @@
   <dependencies>
     <!-- Your dependencies go here -->
   </dependencies>
+  <repositories>
+    <repository>
+      <id>akka-secure</id>
+      <name>Akka Secure</name>
+      <url>https://repo.akka.io/rzfWF62AxO3gu_9uXal1adFoxkZqnUXQJoGKTXjfCsL2bjvg/secure</url>
+    </repository>
+  </repositories>
 </project>

--- a/Exercises/7_begin/pom.xml
+++ b/Exercises/7_begin/pom.xml
@@ -20,4 +20,11 @@
   <dependencies>
     <!-- Your dependencies go here -->
   </dependencies>
+  <repositories>
+    <repository>
+      <id>akka-secure</id>
+      <name>Akka Secure</name>
+      <url>https://repo.akka.io/rzfWF62AxO3gu_9uXal1adFoxkZqnUXQJoGKTXjfCsL2bjvg/secure</url>
+    </repository>
+  </repositories>
 </project>

--- a/Exercises/7_solution/pom.xml
+++ b/Exercises/7_solution/pom.xml
@@ -20,4 +20,11 @@
   <dependencies>
     <!-- Your dependencies go here -->
   </dependencies>
+  <repositories>
+    <repository>
+      <id>akka-secure</id>
+      <name>Akka Secure</name>
+      <url>https://repo.akka.io/rzfWF62AxO3gu_9uXal1adFoxkZqnUXQJoGKTXjfCsL2bjvg/secure</url>
+    </repository>
+  </repositories>
 </project>

--- a/Exercises/8_begin/pom.xml
+++ b/Exercises/8_begin/pom.xml
@@ -20,4 +20,11 @@
   <dependencies>
     <!-- Your dependencies go here -->
   </dependencies>
+  <repositories>
+    <repository>
+      <id>akka-secure</id>
+      <name>Akka Secure</name>
+      <url>https://repo.akka.io/rzfWF62AxO3gu_9uXal1adFoxkZqnUXQJoGKTXjfCsL2bjvg/secure</url>
+    </repository>
+  </repositories>
 </project>

--- a/Exercises/8_solution/pom.xml
+++ b/Exercises/8_solution/pom.xml
@@ -20,4 +20,11 @@
   <dependencies>
     <!-- Your dependencies go here -->
   </dependencies>
+  <repositories>
+    <repository>
+      <id>akka-secure</id>
+      <name>Akka Secure</name>
+      <url>https://repo.akka.io/rzfWF62AxO3gu_9uXal1adFoxkZqnUXQJoGKTXjfCsL2bjvg/secure</url>
+    </repository>
+  </repositories>
 </project>

--- a/Exercises/9_begin/pom.xml
+++ b/Exercises/9_begin/pom.xml
@@ -20,4 +20,11 @@
   <dependencies>
     <!-- Your dependencies go here -->
   </dependencies>
+  <repositories>
+    <repository>
+      <id>akka-secure</id>
+      <name>Akka Secure</name>
+      <url>https://repo.akka.io/rzfWF62AxO3gu_9uXal1adFoxkZqnUXQJoGKTXjfCsL2bjvg/secure</url>
+    </repository>
+  </repositories>
 </project>

--- a/Exercises/9_solution/pom.xml
+++ b/Exercises/9_solution/pom.xml
@@ -20,4 +20,11 @@
   <dependencies>
     <!-- Your dependencies go here -->
   </dependencies>
+  <repositories>
+    <repository>
+      <id>akka-secure</id>
+      <name>Akka Secure</name>
+      <url>https://repo.akka.io/rzfWF62AxO3gu_9uXal1adFoxkZqnUXQJoGKTXjfCsL2bjvg/secure</url>
+    </repository>
+  </repositories>
 </project>


### PR DESCRIPTION
Enable exercises to resolve dependencies from Akka’s secure Maven repository. Supports builds requiring private artifacts.

Closes: lightbend/kalix#13857